### PR TITLE
feat: add configurable strategic priorities text to public registration page

### DIFF
--- a/app/api/public/teams/[teamId]/route.ts
+++ b/app/api/public/teams/[teamId]/route.ts
@@ -21,6 +21,7 @@ export async function GET(
       },
       select: {
         name: true,
+        strategicPriorities: true,
       },
     });
 

--- a/app/api/teams/[teamId]/route.ts
+++ b/app/api/teams/[teamId]/route.ts
@@ -24,7 +24,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ te
   try {
     const { teamId } = await params;
     const body = await request.json();
-    const { name, email, phone, address, postalCode, city, country, website, bankDetails, user } = body;
+    const { name, email, phone, address, postalCode, city, country, website, strategicPriorities, bankDetails, user } = body;
 
     // Start a transaction to handle all updates
     const team = await prisma.$transaction(async (tx) => {
@@ -76,6 +76,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ te
           city,
           country,
           website,
+          strategicPriorities,
           bankDetailsId,
         },
         include: {

--- a/app/public/[teamId]/register/page.tsx
+++ b/app/public/[teamId]/register/page.tsx
@@ -28,10 +28,11 @@ export default function RegisterPage() {
   const { toast } = useToast();
   const params = useParams();
   const [teamName, setTeamName] = useState<string>("");
+  const [strategicPriorities, setStrategicPriorities] = useState<string>("");
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    async function fetchTeamName() {
+    async function fetchTeamData() {
       try {
         const response = await fetch(`/api/public/teams/${params.teamId}`);
         if (!response.ok) {
@@ -40,6 +41,7 @@ export default function RegisterPage() {
         }
         const data = await response.json();
         setTeamName(data.name);
+        setStrategicPriorities(data.strategicPriorities || "");
       } catch (error) {
         toast({
           title: "Error",
@@ -51,7 +53,7 @@ export default function RegisterPage() {
       }
     }
 
-    fetchTeamName();
+    fetchTeamData();
   }, [params.teamId, toast, router]);
 
   const form = useForm<z.infer<typeof createOrganizationSchema>>({
@@ -141,6 +143,16 @@ export default function RegisterPage() {
           <CardDescription>
             Please fill out the form below to request an organization account with {teamName}. We will review your application and get back to you soon.
           </CardDescription>
+          {strategicPriorities && (
+            <div className="mt-4 p-4 bg-muted/50 rounded-lg border">
+              <h3 className="font-semibold text-sm text-muted-foreground mb-2">
+                About {teamName}
+              </h3>
+              <div className="text-sm whitespace-pre-wrap text-foreground">
+                {strategicPriorities}
+              </div>
+            </div>
+          )}
         </CardHeader>
         <CardContent>
           <fieldset disabled={form.formState.isSubmitting}>

--- a/app/teams/[teamId]/settings/page.tsx
+++ b/app/teams/[teamId]/settings/page.tsx
@@ -4,6 +4,7 @@ import {  getEmailTemplates } from "@/services/email-templates";
 import { EmailTemplate } from "@/types";
 
 import CreateEmailTemplate from "@/components/forms/create-email-template";
+import StrategicPrioritiesForm from "@/components/forms/strategic-priorities";
 
 interface PageProps {
   params: Promise<{
@@ -23,11 +24,14 @@ export default async function Page({ params }: PageProps) {
         <h1 className="text-3xl font-bold">Team Settings</h1>
         <p className="text-muted-foreground mt-2">{`Manage your team's settings and email templates`}</p>
       </div>
-      <Card>
-        <div className="space-y-4">
-          <CreateEmailTemplate teamId={teamId} templates={templates.filter(template => template.teamId !== null) as EmailTemplate[]} />
-        </div>
-      </Card>
+      <div className="space-y-8">
+        <StrategicPrioritiesForm teamId={teamId} />
+        <Card>
+          <div className="space-y-4">
+            <CreateEmailTemplate teamId={teamId} templates={templates.filter(template => template.teamId !== null) as EmailTemplate[]} />
+          </div>
+        </Card>
+      </div>
     </div>
   );
 }

--- a/components/forms/strategic-priorities.tsx
+++ b/components/forms/strategic-priorities.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { Form } from "@/components/ui/form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useToast } from "@/hooks/use-toast";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "../ui/card";
+import ButtonControl from "../helper/button-control";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { Textarea } from "@/components/ui/textarea";
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+
+const strategicPrioritiesSchema = z.object({
+  strategicPriorities: z.string().optional(),
+});
+
+interface StrategicPrioritiesFormProps {
+  teamId: string;
+}
+
+export default function StrategicPrioritiesForm({ teamId }: StrategicPrioritiesFormProps) {
+  const { toast } = useToast();
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(true);
+
+  const form = useForm<z.infer<typeof strategicPrioritiesSchema>>({
+    resolver: zodResolver(strategicPrioritiesSchema),
+    defaultValues: {
+      strategicPriorities: "",
+    },
+  });
+
+  useEffect(() => {
+    async function fetchTeamData() {
+      try {
+        const response = await fetch(`/api/teams/${teamId}`);
+        if (response.ok) {
+          const data = await response.json();
+          form.reset({
+            strategicPriorities: data.strategicPriorities || "",
+          });
+        }
+      } catch (error) {
+        console.error("Error fetching team data:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    fetchTeamData();
+  }, [teamId, form]);
+
+  async function onSubmit(values: z.infer<typeof strategicPrioritiesSchema>) {
+    try {
+      const response = await fetch(`/api/teams/${teamId}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(values),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        toast({
+          title: "Error",
+          description: data.error || response.statusText,
+          variant: "destructive",
+        });
+        return;
+      }
+
+      toast({
+        title: "Success",
+        description: "Strategic priorities updated successfully",
+        variant: "default",
+      });
+
+      router.refresh();
+    } catch (e) {
+      toast({
+        title: "Error",
+        description: (e as Error).message,
+        variant: "destructive",
+      });
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <Card className="w-full">
+        <CardContent className="py-6">
+          <div className="text-center">Loading...</div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle>Registration Page Information</CardTitle>
+        <CardDescription>
+          Configure the text that appears on your public registration page to inform organizations about your strategic priorities and available grants.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            <FormField
+              control={form.control}
+              name="strategicPriorities"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Strategic Priorities & Available Grants</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Enter information about your team's strategic priorities, available grants, and any other details organizations should know when registering..."
+                      className="min-h-[150px]"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                  <p className="text-sm text-muted-foreground">
+                    This text will be displayed prominently at the top of your public registration page to help organizations understand your focus areas and available funding opportunities.
+                  </p>
+                </FormItem>
+              )}
+            />
+
+            <ButtonControl 
+              className="w-32" 
+              type="submit" 
+              disabled={form.formState.isSubmitting}
+              label="Save Changes"
+            />
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -132,6 +132,7 @@ model Teams {
   city        String?          @db.VarChar(255)  
   country     String?          @db.VarChar(255)  
   website     String?          @db.VarChar(255)
+  strategicPriorities String?  @db.Text
 
   bankDetailsId String?        @unique
   bankDetails   BankDetails?   @relation(fields: [bankDetailsId], references: [id])

--- a/validations/team.tsx
+++ b/validations/team.tsx
@@ -9,6 +9,7 @@ const createTeamSchema = z.object({
   city: z.string().min(1, "City is required"),
   country: z.string().min(1, "Country is required"),
   website: z.string().min(1, "Website is required"),
+  strategicPriorities: z.string().optional(),
   user: z.object({
     name: z.string().min(1, "Name is required"),
     email: z.string().email("Invalid email address"),


### PR DESCRIPTION
Add strategic priorities field to Teams model and create UI for teams to configure text that displays on their public registration page. Organizations can now see information about the team's strategic priorities and available grants before registering.

**Changes:**
- Add strategicPriorities field to Teams database schema
- Update public teams API to return strategic priorities text
- Update teams API to handle strategic priorities updates
- Create StrategicPrioritiesForm component for team settings
- Display strategic priorities text in highlighted box on registration page
- Update validation schemas and type definitions

Fixes #17

Generated with [Claude Code](https://claude.ai/code)